### PR TITLE
fixes reloading crash in iOS Simulator

### DIFF
--- a/ios/RNTurbolinksManager.swift
+++ b/ios/RNTurbolinksManager.swift
@@ -17,7 +17,19 @@ class RNTurbolinksManager: RCTEventEmitter {
     var userAgent: String?
     var customMenuIcon: UIImage?
     var loadingView: String?    
-    var processPool = WKProcessPool()
+    fileprivate var _processPool: WKProcessPool?
+    
+    var processPool: WKProcessPool {
+        if (_processPool == nil) {
+            _processPool = WKProcessPool()
+        }
+        return _processPool!;
+    }
+
+    deinit {
+        // freeing processPool explicitly otherwise iOS crashes on reload in simulator
+        _processPool = nil
+    }
     
     fileprivate var application: UIApplication {
         return UIApplication.shared


### PR DESCRIPTION
If you reload the UI in the iOS simulator to get a crash due to over releasing the process pool. 
Now the process pool gets released during deinit explicitly.